### PR TITLE
pkg/linksharing/sharing: remove unused image code

### DIFF
--- a/pkg/linksharing/sharing/assets/templates/single-object.html
+++ b/pkg/linksharing/sharing/assets/templates/single-object.html
@@ -69,7 +69,6 @@
           <img class="embed-responsive embed-responsive-4by3" id="imgTag" alt="preview image">
           <video class="embed-responsive embed-responsive-4by3" id="videoTag" controls></video>
           <audio class="embed-responsive embed-responsive-4by3" id="audioTag" controls></audio>
-          <!-- <img class="embed-responsive embed-responsive-4by3 d-none" id="placeholderImage" src="{{.Base}}/static/img/file-drop-v4.png?v={{.VersionHash}}" alt="placeholder image"> -->
           <div class="d-none" id="placeholderImage" alt="Placeholder image">
             <div class="placeholder-container">
               <div class="placeholder-bg"></div>


### PR DESCRIPTION
The previous linksharing placeholder image is not being used as we replaced it with a css only visual. The code was left commented and now we remove that. Previous PR: https://github.com/storj/edge/pull/465

## Code Review Checklist (to be filled out by reviewer)

 - [x] Are there any authservice's database migrations? Are they forwards _and_ backwards compatible?
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs, it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation needs updating?
 - [x] Do the database access patterns make sense?
 - [ ] Copy the Commit Message Body section contents into the submit prompt upon PR completion
